### PR TITLE
Added the ability to create profiles in the RDG file with new params

### DIFF
--- a/RDPs2RDG.ps1
+++ b/RDPs2RDG.ps1
@@ -38,7 +38,7 @@
     Switch to turn on extra debug logging 
 
  .EXAMPLE
-    RDPs2RDG.ps1 -DefaultLogonName WsAdm -DefaultLogonDomain mydomain -RdpFilesPath C:\RDPs -WorkspaceName MyWorkspace
+    RDPs2RDG.ps1 -DefaultLogonName WsAdm -DefaultLogonDomain mydomain -RdpFilesPath C:\RDPs -WorkspaceName MyWorkspace -Users "jsmith,mroony,aguy" -DefaultPassword "testPassword"
 
  .NOTES
      File Name  : RDPs2RDG.ps1

--- a/RDPs2RDG.ps1
+++ b/RDPs2RDG.ps1
@@ -204,8 +204,8 @@ foreach ($RdpFile in $RdpFiles)
     }
 }#for-each RDP file
 
-if($users.Length -gt 0){
-    $userArray =  $users.Split($(",;".ToCharArray()))
+if($Users.Length -gt 0){
+    $userArray =  $Users.Split($(",;".ToCharArray()))
     foreach($user in $userArray){
         $profileTemplate = @"
             <credentialsProfile inherit="None">
@@ -216,7 +216,7 @@ if($users.Length -gt 0){
             </credentialsProfile>
 "@
 
-            $encPass = encryptPass -plaintext $defaultPassword
+            $encPass = encryptPass -plaintext $DefaultPassword
 
             [xml]$xmlTemplate = $profileTemplate -f $DefaultLogonDomain, $user, $encPass
 
@@ -229,7 +229,7 @@ if($users.Length -gt 0){
                 If ($debugging) {Write-Host "Added user credentials for: '$user'" -ForegroundColor Cyan}
             }
     }#for-each user
-}#if users specified
+}#if Users specified
 
 #Save final RDCMan file
 $RDCConfig.Save($NewRDCFile)


### PR DESCRIPTION
The new params added allow the RDG file to create profiles with a default password which is commonly used in test environments.

I updated the documentation in the file header too.

You now provide these 2 params-
-Users "johnDoe,janeDoe,samSmith" -DefaultPassword "myPassword"
This will create profiles with the DefaultLogonDomain\UserName format, using the DefaultLogonDomain parameter.